### PR TITLE
Move specs from the wiki over to GitHub

### DIFF
--- a/archival/archival.md
+++ b/archival/archival.md
@@ -1,0 +1,6 @@
+# Archival Intent
+
+This intent is for long-term archival and does not allow any application
+specific extensions. It places additional restrictions on the Baseline Intent.
+
+Archival intent is under discussion.

--- a/baseline/baseline.md
+++ b/baseline/baseline.md
@@ -1,0 +1,11 @@
+# Baseline Intent
+
+Every OpenRaster file is compliant to Baseline.
+
+This intent is for exchange between applications and it is allowed to have
+custom extensions in such a file.
+
+Baseline intent is covered by these two specs:
+
+* File Layout Specification
+* Layer Stack Specification

--- a/baseline/file-layout-spec.md
+++ b/baseline/file-layout-spec.md
@@ -1,0 +1,69 @@
+# File Layout Specification
+
+## Storage
+
+OpenRaster files have the file name extension .ora. The data is stored within
+a [Zip file](http://www.pkware.com/documents/casestudies/APPNOTE.TXT) wrapper.
+
+Technical note: Zip files can use a different compression algorithm on a
+per-file basis. Only DEFLATED and STORED should be used for OpenRaster files.
+The file names within OpenRaster "zip files" are case-sensitive and must be
+UTF-8 encoded. If you decide to write non-ascii file names, be aware that the
+Zip format has an UTF-8 flag for each file name. Make sure this flag is set,
+otherwise the content might get decoded as cp437. Note also that the Zip file
+format has a 64 bit extension which must be enabled to write files larger than
+4GB.
+
+This file format is hereafter referred to as an "OpenRaster file" in this
+specification. It has a number of required and optional standard files and
+subdirectories within it:
+
+	example.ora  [considered as a folder-like object]
+	 ├ mimetype
+	 ├ stack.xml
+	 ├ data/
+	 │  ├ [image data files referenced by stack.xml, typically layer*.png]
+	 │  └ [other data files, indexed elsewhere]
+	 ├ Thumbnails/
+	 │  └ thumbnail.png
+	 └ mergedimage.png
+
+## Required Files
+
+### mimetype
+
+The first file in the archive must be called `"mimetype"`, without a file name
+extension. It must be STORED without compression. This file must contain the
+string `"image/openraster"`, with no whitespace or trailing newline.
+
+### stack.xml
+
+This is the UTF-8 encoded XML file from the Layers Stack Specification.
+
+### data
+
+This directory is (by convention) where data files are usually stored. Files
+must be referenced in stack.xml by their full path relative to the OpenRaster
+file's root, e.g. `"data/layer2.png"`.
+
+All files inside this directory should be referenced from somewhere. Well known
+file name extensions (like `.png`) should be lower case. 
+
+### Thumbnails/thumbnail.png
+
+An OpenRaster file must have a `thumbnail.png` in order to allow file browser
+software to render the thumbnail efficiently. It must be a non-interlaced PNG
+with 8 bits per channel of at most 256x256 pixels. It should be as big as
+possible without upscaling or changing the aspect ratio. Any aspect ratio is
+permitted. It should not contain any frame or decoration.
+
+The thumbnail file must not be referenced in any `.xml` file. 
+
+## Optional Files
+
+### mergedimage.png
+
+An OpenRaster file must have a `mergedimage.png` in order to accommodate viewer
+software. It must contain the final rendered image without any frame or
+decoration. This file must be a PNG file with 8 or 16 bits per channel. *(Since
+0.0.2, this file is mandatory.)*

--- a/baseline/layer-stack-spec.md
+++ b/baseline/layer-stack-spec.md
@@ -1,0 +1,299 @@
+# Layer Stack Specification
+
+Note: this is an early draft of the specification, do not take anything on this
+page for granted. Pretty much everything is open for discussion. 
+
+## Introduction
+
+This document specifies the [OpenRaster](https://github.com/openraster/ora-spec)
+Layer Stack XML format. The main two goals of the specification are
+interoperability between applications and allowing files to be saved without
+destructive pixel operations.
+
+Note that this document does not define how the data is stored, and especially
+doesn't address the issue of how to store pixels nor how OpenRaster files can
+be stored on disk. This document doesn't address the mathematics behind layer
+compositing operations: it's simpler to describe that using other standard
+bodies' documents at this stage.
+
+The first part of the document explains the concept of a baseline Layer Stack,
+with examples. Each attribute and element defined by the baseline profile is
+explained individually.
+
+## Baseline documents
+
+A baseline OpenRaster document is a document that can be opened and look
+similar on all applications and platforms. The baseline layer stack format
+defines the minimum requirement to achieve interoperability and what is unsafe
+for interoperability. Layer Stack format permits extensions, which should be
+individually specified in detail, and work safely with the baseline profile.
+
+Some users will require full interoperability, to create files which can be
+edited on every application supporting OpenRaster. Other users will only need
+to view OpenRaster files. This specification defines two classes of baseline
+support:
+
+* "Full baseline", which allows reading and editing
+* "Viewing baseline" which guarantees visualization of the file, but editing
+might damage the result
+
+## Syntax
+
+The formal syntax of the layer stack is given following the
+
+* https://gitorious.org/openraster/openraster-standard/blobs/master/schema.rnc (compact format, canonical schema)
+* https://gitorious.org/openraster/openraster-standard/blobs/master/schema.rng (xml format)
+
+## Example
+
+	<?xml version='1.0' encoding='UTF-8'?>
+	<image version="0.0.3" w="300" h="177" xres="600" yres="600">
+	  <stack>
+	    <stack x="10">
+	      <stack>
+	        <layer name="OpenRaster Logo" src="data/hw.svg" x="5" y="5" />
+	        <text x="50" y="10">Use a Rich Text XML Specification to write cool text in your OpenRaster File</text>
+	      </stack>
+	    </stack>
+	    <!-- filters are syntactically permissible, but not valid for baseline -->
+	    <layer name="layer1" src="data/image1.png" />
+	  </stack>
+	</image>
+
+## Elements and Attributes
+
+### image element
+
+This is the root element of the file. The logical size of the image is given
+by the mandatory `"w"` and `"h"` attributes, which are positive integers. The
+content expressed within `image` may have extents which can be smaller or
+larger, and so the image should be cropped to (0,0,w,h) when displaying,
+printing, or otherwise exporting to a context which requires a rectangular
+image.
+
+* The mandatory `"version"` attribute specifies the version of the OpenRaster
+specification to which the OpenRaster file as a whole conforms. Values are
+[xsd:string](http://www.w3.org/TR/xmlschema-2/#string)s which conform to
+[SemVer 2.0.0](http://semver.org/spec/v2.0.0.html). (Since: 0.0.1)
+* The optional `xres` and `yres` attributes specify the nominal resolution of
+the document as a whole in the horizontal and vertical dimensions, in pixels
+per inch. Values are [xsd:int](http://www.w3.org/TR/xmlschema-2/#int)s with a
+minimum value of 1. The default value, if unspecified, is 72. If either is
+specified, the other must also be specified. Applications should preserve
+resolution information specified in the document in both directions unless it
+is adjusted by the user, even if they make the simplifying assumption that
+`xres` is equal to `yres`. *(Since: 0.0.3)*
+
+### Common attributes for layer and non-root stack elements
+
+#### x and y attributes
+
+Position attributes. These are signed integers with a default value of 0.
+
+#### name attribute
+
+The name of the object represented by an element. A Unicode string, encoded in
+the XML document's own encoding.
+
+#### opacity attribute
+
+The object's opacity, expressed as a simple floating-point number. Values
+between 0.0 for fully transparent, and 1.0 for fully opaque.
+
+#### visibility attribute
+
+The visibility of the object.
+
+* Valid values are either visible, or hidden.
+* Default value: visible.
+
+#### composite-op attribute
+
+The operation to use when rendering this stack or layer over its backdrop.
+The effect is to be calculated as described in 
+[Compositing-1: General Formula for Compositing and Blending](http://www.w3.org/TR/compositing-1/#generalformula),
+namely as combinations of a colour *blending function* and a Porter-Duff alpha
+compositing operator. This attribute's name is perhaps a misnomer now, but it
+reflects the history of the OpenRaster specification and the evolution of the
+attribute from its inspirations in the earlier
+[SVG 1.2 Working Draft](http://dev.w3.org/SVG/modules/compositing/master/SVGCompositing.html#comp-op-property)
+and in [GEGL's named processing "operations"](http://www.gegl.org/operations.html),
+which also provide the seeds of the naming scheme for values below.
+
+<table border="1" cellpadding="5" cellspacing="0">
+<tr>
+  <th>Value</th>
+  <th>Blending function</th>
+  <th>Compositing Operator</th>
+</tr>
+<tr>
+  <td>svg:src-over</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingnormal">Normal</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:multiply</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingmultiply">Multiply</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:screen</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingscreen">Screen</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:overlay</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingoverlay">Overlay</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:darken</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingdarken">Darken</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:lighten</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendinglighten">Lighten</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:color-dodge</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingcolordodge">Color Dodge</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:color-burn</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingcolorburn">Color Burn</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:hard-light</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendinghardlight">Hard Light</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:soft-light</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingsoftlight">Soft Light</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:difference</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingdifference">Difference</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:color</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingcolor">Color</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:luminosity</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingluminosity">Luminosity</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:hue</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendinghue">Hue</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:saturation</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingsaturation">Saturation</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcover">Source Over</a></td>
+</tr>
+<tr>
+  <td>svg:plus</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingnormal">Normal</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_plus">Lighter</a></td>
+</tr>
+<tr>
+  <td>svg:dst-in</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingnormal">Normal</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_dstin">Destination In</a></td>
+</tr>
+<tr>
+  <td>svg:dst-out</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingnormal">Normal</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_dstout">Destination Out</a></td>
+</tr>
+
+<tr>
+  <td>svg:src-atop</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingnormal">Normal</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcatop">Source Atop</a></td>
+</tr>
+<tr>
+  <td>svg:dst-atop</td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#blendingnormal">Normal</a></td>
+  <td><a href="http://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_dstatop">Destination Atop</a></td>
+</tr>
+</table>
+
+The default value is `svg:src-over`, which represents simple alpha compositing.
+
+In the future other compositing modes might be added, and a way for applications
+to define new modes will be specified.
+
+#### stack element
+
+The `stack` element describes a group of layers. They may contain sub-`stack`s,
+`layer`s, or `text` elements. The first element in a stack is the uppermost.
+
+The following attributes are optional on non-root `stack`s, but must be omitted
+on the root stack.
+
+* `name`
+* `x and y`
+* `opacity`
+* `visibility`
+* `composite-op`
+
+
+#### layer element
+
+The `layer` element defines a graphical layer within a layer stack, stored in a
+separate file within the OpenRaster file. The following attribute is required:
+
+* `"src"`: the path to the stored data file for this layer. See the File Layout
+Specification for an explanation of the values which can go here.
+
+The following attributes are optional on `layer` elements:
+
+* `name`
+* `x and y`
+* `opacity`
+* `visibility`
+* `composite-op`
+
+#### text element
+
+TODO: define it! Ideally, use another rich text specification, e.g. a relevant
+subset of the OpenDocument Text specification or XHTML.
+
+### Compositing the image
+
+Layer stacks should be composited in a manner conforming to the W3C's
+[Compositing and Blending Level 1 Candidate Recommendation](http://www.w3.org/TR/compositing-1/).
+In terms of this specification's rendering model, some OpenRaster layer stacks
+or nested sub-stacks are *isolated* groups, but some sub-stacks may be
+non-isolated.
+
+[Isolated groups](http://www.w3.org/TR/compositing-1/#isolatedgroups) are always
+rendered independently at first, starting with a fully-transparent 'black'
+backdrop (rgba={0,0,0,0}). The results of this independent composite are then
+rendered on top of the group's own backdrop using the group's opacity and
+composite mode settings. Conversely non-isolated groups are rendered by
+rendering each child layer or sub-stack in turn to the group's backdrop, just as
+if there were no stacked group.
+
+* The root stack has a fixed, implicit rendering in OpenRaster: it is to
+composite as an isolated group over a background of the application's choice.
+* Non-root stacks should be rendered as isolated groups if: a) their `isolation`
+property is `isolate` (and not `auto`); or b) their `opacity` is less that 1.0;
+or c) they use a `composite-op` other than `svg:src-over`. This inferential
+behaviour is intended to provide backwards compatibility with apps which
+formerly didn't care about group isolation.
+
+Applications may assume that all stacks are isolated groups if that is all they
+support. If they do so, they must declare when writing OpenRaster files that
+their layer groups are isolated (`isolation='isolate'`). (Since: 0.0.4)

--- a/extensions/extensions.md
+++ b/extensions/extensions.md
@@ -1,0 +1,10 @@
+# Extensions
+
+This describes optional features that are not part of baseline. Extensions
+should have published working code, and be supported in more than one
+OpenRaster-aware application.
+
+Currently available extensions are:
+
+* Layer Selection Status — load and save layer selection state
+* Layer Edit Locking Status — load & save layer immutability state

--- a/extensions/layer-edit-locking-status.md
+++ b/extensions/layer-edit-locking-status.md
@@ -1,0 +1,48 @@
+# Layer Edit Locking Status
+
+Editor applications sometimes have a concept of layers which are currently
+locked to prevent accidental editing. This state should be saved as part of
+OpenRaster files which might be opened again for editing in order to assist user
+workflow. Therefore, the `<layer/>` element in a layer stack definition should
+support the following extra attribute:
+
+* `"edit-locked"`: the layer edit locking status, expressed as an
+[xsd:boolean](http://www.w3.org/TR/xmlschema-2/#boolean). True values (`"true"`,
+canonically) mean that the layer was locked to prevent accidental edits by the
+user, and should be regarded as un-editable after loading if such immutable
+layers are supported by the editor. False values (`"false"`, canonically)
+indicate that the layer is not edit locked, and should be treated as editable
+immediately after loading. The default is false. (It is intended that other
+kinds of "locking", e.g. alpha locking which makes the alpha channel of a layer
+immutable, should suffix their attribute names with the string `"-locked"` for
+consistency. Don't just use `"locked"` on its own; there's more than one kind of
+immutability.)
+
+## Example
+
+When a user does not wish to accidentally paint colour onto a monochrome sketch
+layer, they may wish to edit-lock that layer in the user interface. When the
+working document is saved, such a layer stack might be saved as:
+
+	<stack>
+		<layer name="sketch" x="0" y="0" src="data/layer001.png" edit-locked="true"/>
+		<layer name="colours" x="-512" y="-128" src="data/layer002.png"/>
+	</stack>
+
+## Impact on Applications
+
+This change has no impact on the viewing baseline intent.
+
+Applications supporting the full baseline intent which permit layers to be made
+immutable by the user to prevent accidental edits should mark edit-locked layers
+with the edit-locked attribute when saving, and restore their edit-locked state
+when loading. Applications may impose their own definition of what edit-locked
+actually means; for example, in MyPaint, layers marked as locked in this way
+cannot be painted to, but are also unavailable for selection by brushstroke or
+for brushstroke picking.
+
+The edit-locked attribute must be omitted when saving for the archival intent.
+
+## Support
+
+Implemented in Krita and MyPaint development trunks since 2012-03-26.

--- a/extensions/layer-selection-status.md
+++ b/extensions/layer-selection-status.md
@@ -1,0 +1,42 @@
+# Layer Selection Status
+
+Editor applications normally have a concept of which layer or layers, are
+currently selected by the user for editing. It is more convenient for the user
+if such applications save this information to OpenRaster files, and are able to
+select the same layer or layers again when the file is reloaded. Therefore, the
+`<layer/>` element in a layer stack definition should support the following
+extra attribute:
+
+* `"selected"`: the layer selection status, expressed as an
+[xsd:boolean](http://www.w3.org/TR/xmlschema-2/#boolean). True values (`"true"`,
+canonically), mean that the layer is selected by the user, and may be made
+active for editing after loading. False values (`"false"`, canonically) indicate
+that the layer is not selected. The default is false.
+
+## Example
+
+	<stack>
+		<layer name="sketch" x="0" y="0" src="data/layer001.png"/>
+		<layer name="colours" x="-512" y="-128" src="data/layer002.png" selected="true"/>
+	</stack>
+
+## Impact on Applications
+
+This change has no impact on the viewing baseline intent.
+
+Apps supporting the full baseline intent which permit layers to be chosen by the
+user for editing or any other purpose should mark a single such chosen layer as
+`selected` when saving, ideally a layer currently receptive to editing. Upon
+loading, apps should respect the user selection and should make any layer marked
+as `selected` both selected in the interface and, if supported, receptive to
+editing. When loading, it is acceptable to make only a single layer selected
+(and possibly receptive to editing) if that is all that is supported and
+multiple layers are marked as `selected` in the OpenRaster file being loaded.
+The choice of which layer to make active is left as an implementation detail,
+but should be guided by the `selected` attributes of layers.
+
+The selected attribute must be omitted when saving for the archival intent.
+
+## Support
+
+Implemented in Krita and MyPaint development trunks since 2012-03-26.

--- a/proposals/animation.md
+++ b/proposals/animation.md
@@ -1,0 +1,23 @@
+# Animation
+
+*Status*: proposal
+
+*Author*: Efa (& others?)
+
+*Submission date*: 19 October, 2010
+
+*Implementations*: none
+
+One OpenRaster file would be able to contain more than one image. This would
+be useful for things like sketchbooks, comic stories, or anything else where
+you might want to have raster images in sequence but where using separate image
+files would be impractical.
+
+File contains timing for every raster image, and a jump/loop count settings.
+
+Any program that does not support animation OpenRaster files would simply show
+the first raster and hide the others (or, perhaps, show a raster defined as
+“default” by the image author).
+
+Any program could implement, crudely, something like this using layer groups.
+However, that would be unlikely to be recognized across implementations.

--- a/proposals/embed-fonts.md
+++ b/proposals/embed-fonts.md
@@ -1,0 +1,18 @@
+# Embed Fonts as TTF Files
+
+*Status*: proposal
+
+*Author*: Marcos
+
+*Submission date*: 28 May, 2010
+
+*Implementations*: none
+
+To improve the user experience and maximize the representation accuracy is
+possible to store the `.ttf` fonts inside the `.ora` files.
+
+Additionally the implementation must check if the font is libre, then:
+
+* If it is libre: embed it directly into the .ora
+* If it is not libre: alert the user about the license issues, and offer to
+avoid the embedding or to embed it despite of the legal issues.

--- a/proposals/filter-effects.md
+++ b/proposals/filter-effects.md
@@ -1,0 +1,148 @@
+# Filter Effects
+
+*Status*: proposal (currently unimplemented?)
+
+*Author*: unknown
+
+*Submission date*: 18 May, 2013
+
+*Implementations*: unknown
+
+*Note*: this is an early draft of the specification, do not take anything on
+this page for granted, pretty much everything is open for discussion.
+
+As a standard extension, outside baseline but defined in the standard schema,
+OpenRaster layers stacks should be able to contain parameterised filters which
+themselves might contain sub-stacks. This document shows how the extension would
+be integrated into baseline OpenRaster stack.xml syntax, describes the
+additional elements and attributes, and lists the available filters.
+
+	<stack>
+		<stack>
+			<filter name="invert" type="invert" />
+			<!-- layers -->
+		</stack>
+		<!-- ... layers ... -->
+		<filter name="filter1" type="standard:gaussianblur">
+			<params>
+				<param name="radius">10</param>
+			</params>
+			<stack>
+				<layer name="mask2" src="data/mask2.data" composite-op="svg:src-over" />
+    			<layer name="mask1" src="data/mask1.png" />
+			</stack>
+		</filter>
+		<!-- ... more layers ... -->
+	</stack>
+
+## Semantics
+
+TODO: define how flters are to be applied. Presumably to just the layers inside
+the nested `<stack/>` element? If so, how is the result to be composited onto
+the results of the layers below?
+
+### filter element
+
+This element defines a layer which instead of containing pixel data, applies a
+filter onto the composited result of the layers below it in the stack.
+The attributes are:
+
+* `"type"`: the type of the filter. Type names make use of namespaces, they must
+have the following form: "namespace:name". Three namespaces are defined:
+  * `"standard"`: for the list of filters and the associated mathematics, see
+  the relevant OpenRaster specification
+  * `"composite"`: composite filter are filters which are a composition of a
+  list of standard filters. The name must be the name of a filter defined in the
+  same file.
+  * `"application"`: non-standard filters; the name is formed as followed
+  "application:filtername". For example, for an application called MyGraphApp,
+  the full name is "application:MyGraphApp:MyFilter". Use of such a type of
+  filter prevents the file from being a Full Baseline OpenRaster file; however
+  use of the `"output"` attribute defined below allows the file to be conformant
+  to the Viewing Baseline.
+* `"output"`: the file name of the data of the filter output, this attribute is
+only needed when the type of the filter is of the "application" namespace, and
+if the user wants to create a Viewing Baseline layer stack.
+
+### params element
+
+This element is used to describe the parameters used for a filter layer. The
+standard filters each have a defined list of parameters, defined permissible
+values. Attributes:
+
+* `"version"`: correspond to the version of the filter, either the version of
+the filter specification for standard filter, or any number defined by the
+application for application-specific filters.
+
+### param element
+
+Description of the attributes:
+
+* `"name"`: the name of the parameter. The parameter's value is formed by the
+content of the param element.
+
+For "composite" filters, the `params` element allows variables to be defined
+which are then used to parameterise each contained filter. For example, consider
+a composite function composed of `"standard:blur"` filter with the parameter
+`"radius"` applied with a `"standard:invert"` filter. It is defined as follows
+in the composite section:
+
+	<compositefilter name="blurinvert" >
+		<filter name="blur">
+			<params>
+				<param name="radius">
+					@R@
+				</param>
+			</params>
+		</filter>
+		<filter name="invert" />
+	</compositefilter>
+
+Then the usage would be:
+
+	<filter name="composite:blurinvert" >
+		<params>
+			<param name="R">10</param>
+		</params>
+	</filter>
+
+TODO: reconsider this, is it useful ? it just come out of my mind that is the
+only usefull use of parameters for composite filter, but if it's useless, let's
+not allow any parameters for them!
+
+## Standard Filters
+
+The mathematics behind each filter is described in the SVG 1.1 Specification,
+and each filter accepts the same parameters.
+
+OpenRaster files may use filters not described in this document, in which case
+the file won't be valid for interoperability, unless the result of the operation
+is also available (see the output attribute above).
+
+### ColorMatrix
+
+See [SVG 1.1 Specification](http://www.w3.org/TR/SVG11/filters.html#feColorMatrixElement).
+
+### ConvolveMatrix
+
+See [SVG 1.1 Specification](http://www.w3.org/TR/SVG11/filters.html#feConvolveMatrixElement).
+
+### ComponentTransfer
+
+See [SVG 1.1 Specification](http://www.w3.org/TR/SVG11/filters.html#feComponentTransferElement).
+
+### GaussianBlur
+
+See [SVG 1.1 Specification](http://www.w3.org/TR/SVG11/filters.html#feGaussianBlurElement).
+
+### Tile
+
+See [SVG 1.1 Specification](http://www.w3.org/TR/SVG11/filters.html#feTileElement).
+
+### Morphology
+
+See [SVG 1.1 Specification](http://www.w3.org/TR/SVG11/filters.html#feMorphologyElement).
+
+### Distortion correction
+
+### Burn and Dodge

--- a/proposals/multiple-pages.md
+++ b/proposals/multiple-pages.md
@@ -1,0 +1,21 @@
+# Multiple Pages
+
+*Status*: proposal
+
+*Author*: Tina Russell
+
+*Submission date*: 5 August, 2010
+
+*Implementations*: none
+
+One OpenRaster file would be able to contain more than one page. This would be
+useful for things like sketchbooks, comic stories, or anything else where
+you might want to have raster images in sequence but where using separate image
+files would be impractical.
+
+Any program which does not support multi-page OpenRaster files would simply
+show the first page and hide the others (or, perhaps, show a page defined as
+“default” by the image author).
+
+Any program could implement, crudely, something like this using layer groups.
+However, that would be unlikely to be recognized across implementations.

--- a/proposals/palette.md
+++ b/proposals/palette.md
@@ -1,0 +1,14 @@
+# palette.gpl or palette.xml (MyPaint proposal)
+
+*Status*: proposal
+
+*Author*: Portnov
+
+*Submission date*: 30 September, 2009
+
+*Implementations*: none
+
+Color swatches set (as additional info for editing application) can be saved
+in `palette.gpl` in GIMP's `.gpl` format, or in `palette.xml` in XML format.
+XML format should base on
+[/SwatchesFileFormatDraft](https://www.freedesktop.org/wiki/Specifications/OpenRaster/Draft/Palette/SwatchesFileFormatDraft/).

--- a/proposals/palette.md
+++ b/proposals/palette.md
@@ -11,4 +11,4 @@
 Color swatches set (as additional info for editing application) can be saved
 in `palette.gpl` in GIMP's `.gpl` format, or in `palette.xml` in XML format.
 XML format should base on
-[/SwatchesFileFormatDraft](https://www.freedesktop.org/wiki/Specifications/OpenRaster/Draft/Palette/SwatchesFileFormatDraft/).
+[Swatches File Format Draft](https://www.freedesktop.org/wiki/Specifications/OpenRaster/Draft/Palette/SwatchesFileFormatDraft/).

--- a/proposals/png-data-requirements.md
+++ b/proposals/png-data-requirements.md
@@ -1,0 +1,52 @@
+# PNG Data Requirements
+
+*Status*: proposal
+
+*Author*: unknown
+
+*Submission date*: unknown
+
+*Implementations*: unknown
+
+The OpenRaster specification should place certain limitations on image data
+within `.ora` containers in order to ensure that the widest range of
+applications can open them and display them correctly.
+
+## General PNG data requirements
+
+*Current specification*: File Layout
+
+*Change*: new section
+
+Unless otherwise specified for a particular kind of PNG data stream in an
+OpenRaster file,
+
+* PNG data should not be interlaced (OpenRaster is not a streaming format)
+* Applications reading OpenRaster data should read and process colour management
+chunks present in PNG files as described in the
+[PNG specification](http://www.w3.org/TR/PNG/#4Concepts.ColourSpaces).
+  * This specification does not place requirements on how applications should use
+  this colour management information internally.
+  * It may however express filters or layer blending modes in terms of particular
+  colour spaces.
+* Applications writing OpenRaster files *should* write appropriate colour management
+chunks to each PNG file in the wrapper.
+
+## Layer data requirements
+
+*Current specification*: File Layout ('Data' section)
+
+*Change*: addendum
+
+Stored data files for layers should be encoded in PNG format.
+
+## Thumbnails/thumbnail.png
+
+*Current specification*: ../FileLayout#Thumbnails.2BAC8-thumbnail.png
+
+*Change*: addendum
+
+Thumbnail images *should* be encoded in the sRGB colour space. They should be
+written with an sRGB chunk (and the "Perceptual" rendering intent), and with
+the canonical `cHRM` and `gAMA` chunks and data values for the sRGB encoding
+colour space.

--- a/proposals/proposals.md
+++ b/proposals/proposals.md
@@ -1,0 +1,15 @@
+# Proposals and Application Specific Extensions
+
+Those might move to the Extensions after discussion. Application developers are
+invited to fork the repository and make pull requests. At some point it might be
+proposed for inclusion to the Extensions through the Create mailing list.
+
+Currently available proposals are:
+
+* Effects Specification
+* Palette
+* Embed Fonts (Proposal to extension)
+* Multiple pages
+* Animation support using multiple pages and a timer like PSD do
+* Undo-history support undo/history of commands/actions like PSD do
+* PNG data requirements

--- a/proposals/undo-history.md
+++ b/proposals/undo-history.md
@@ -1,0 +1,16 @@
+# Undo History
+
+*Status*: proposal
+
+*Author*: Efa
+
+*Submission date*: 13 October, 2010
+
+*Implementations*: none
+
+OpenRaster file would be able to contain his undo history, like PSD do. This
+would be useful to continue the editing session in next days or at a later
+time, without loss anything.
+
+Any program which does not support undo history OpenRaster files, would simply
+show the last version of the raster and skip the undo commands history.


### PR DESCRIPTION
I left everything pretty much as is with few exceptions:

1. Slightly more text formatting.
2. Proposals now have a unified beginning of the file, containing Status, Author, Submission Date, and Implementation info.